### PR TITLE
Added X11 keylogger

### DIFF
--- a/ApplicationGlobals.cpp
+++ b/ApplicationGlobals.cpp
@@ -10,9 +10,11 @@ namespace NSApplication {
 // CApplicationGlobals Definition
 //---------------------------------------------------------------------------
 
-CApplicationGlobals::CApplicationGlobals() {
-
+CApplicationGlobals::CApplicationGlobals()
+    : X11Keylogger(new CX11Keylogger)
+{
 }
+
 //---------------------------------------------------------------------------
 } // NSApplication
 //---------------------------------------------------------------------------

--- a/ApplicationGlobals.h
+++ b/ApplicationGlobals.h
@@ -5,6 +5,7 @@
 //---------------------------------------------------------------------------
 
 #include "Qt/MainWindow.h"
+#include "cx11keylogger.h"
 //---------------------------------------------------------------------------
 
 namespace NSApplication {
@@ -31,6 +32,7 @@ class CApplicationGlobals : protected NSQt::CMainWindow {
   using CBase = NSQt::CMainWindow;
 public:
   CApplicationGlobals();
+  std::unique_ptr<CX11Keylogger> X11Keylogger;
 };
 //---------------------------------------------------------------------------
 } // NSApplication

--- a/QtMinimalApp.pro
+++ b/QtMinimalApp.pro
@@ -37,6 +37,8 @@ SOURCES += \
     ApplicationImplementation.cpp \
     Application.cpp \
     ExceptionHandler.cpp \
+    cx11keyloggerworker.cpp \
+    cx11keylogger.cpp \
     main.cpp
 
 
@@ -49,7 +51,12 @@ HEADERS += \
     ApplicationImplementation.h \
     Application.h \
     ExceptionHandler.h \
+    cx11keyloggerworker.h \
+    cx11keylogger.h \
     stdafx.h
 
 FORMS += \
         CMainWindow.ui
+
+LIBS += -lX11 \
+        -lXi

--- a/cx11keylogger.cpp
+++ b/cx11keylogger.cpp
@@ -1,0 +1,18 @@
+#include "cx11keylogger.h"
+#include <cx11keyloggerworker.h>
+
+CX11Keylogger::CX11Keylogger(QObject *parent) : QObject(parent)
+{
+    CX11KeyloggerWorker *worker = new CX11KeyloggerWorker(&workingThread_);
+    worker->moveToThread(&workingThread_);
+    connect(&workingThread_, &QThread::finished, worker, &QObject::deleteLater);
+    connect(this, &CX11Keylogger::Start, worker, &CX11KeyloggerWorker::StartLogging);
+    workingThread_.start();
+    emit Start();
+}
+
+CX11Keylogger::~CX11Keylogger() {
+    workingThread_.requestInterruption();
+    workingThread_.exit(); // this doesn't work until some key is pressed. It can be fixed with terminate(), but it' quite bad method
+    workingThread_.wait();
+}

--- a/cx11keylogger.h
+++ b/cx11keylogger.h
@@ -1,0 +1,23 @@
+#ifndef CX11KEYLOGGER_H
+#define CX11KEYLOGGER_H
+
+#include <QObject>
+#include <QThread>
+
+class CX11Keylogger : public QObject
+{
+    Q_OBJECT
+public:
+    explicit CX11Keylogger(QObject *parent = nullptr);
+    ~CX11Keylogger();
+
+signals:
+    void Start();
+
+public slots:
+
+private:
+    QThread workingThread_;
+};
+
+#endif // CX11KEYLOGGER_H

--- a/cx11keyloggerworker.cpp
+++ b/cx11keyloggerworker.cpp
@@ -1,6 +1,7 @@
 #include "cx11keyloggerworker.h"
 #include <exception>
 #include <iostream> // cout to show that everething works
+#include <vector>
 
 CX11KeyloggerWorker::CX11KeyloggerWorker(QThread* myThread, QObject *parent)
     : QObject(parent)

--- a/cx11keyloggerworker.cpp
+++ b/cx11keyloggerworker.cpp
@@ -1,0 +1,61 @@
+#include "cx11keyloggerworker.h"
+#include <exception>
+#include <iostream> // cout to show that everething works
+
+CX11KeyloggerWorker::CX11KeyloggerWorker(QThread* myThread, QObject *parent)
+    : QObject(parent)
+    , myThread_(myThread)
+{
+    // Setup X11
+    X11Display_ = XOpenDisplay(nullptr);
+    if (X11Display_ == nullptr) {
+        throw std::runtime_error("Cannot open display");
+    }
+
+    // Magic to check if XInput 2 is avaible and find it's opcode
+    int queryEvent, queryError;
+    if (! XQueryExtension(X11Display_, "XInputExtension", &xi_opcode_, &queryEvent, &queryError)) {
+        throw std::runtime_error("X Input extension not available\n");
+    }
+
+    Window X11DefaultWindow = DefaultRootWindow(X11Display_);
+
+    // Setup catching events
+    XIEventMask X11EventMask;
+    X11EventMask.deviceid = XIAllMasterDevices;
+    X11EventMask.mask_len = XIMaskLen(XI_LASTEVENT);
+    X11EventMask.mask = new unsigned char[X11EventMask.mask_len];
+    std::fill(X11EventMask.mask, X11EventMask.mask + X11EventMask.mask_len, 0);
+
+    XISetMask(X11EventMask.mask, XI_RawKeyPress);
+    XISetMask(X11EventMask.mask, XI_RawKeyRelease);
+
+    // third parameter is pointer to the array of Masks, but we have only 1 mask, so we can just take it's address
+    // last parameter is size of the array
+    XISelectEvents(X11Display_, X11DefaultWindow, &X11EventMask, 1);
+    XSync(X11Display_, false);
+    delete[] X11EventMask.mask;
+
+    // Done
+}
+
+void CX11KeyloggerWorker::StartLogging() {
+    XEvent X11CurrentEvent;
+    XGenericEventCookie *X11CurrentEventCookie = &X11CurrentEvent.xcookie;
+    while (!myThread_->isInterruptionRequested()) {
+        // TODO: 100 milliseconds timeout using custom class?
+        XNextEvent(X11Display_, &X11CurrentEvent);
+
+        if (!XGetEventData(X11Display_, X11CurrentEventCookie) || X11CurrentEventCookie->extension != xi_opcode_) {
+            continue;
+        }
+        if (X11CurrentEventCookie->evtype == XI_RawKeyPress) {
+            std::cout << "RawKeyPressed, Symbol: " << XKeysymToString(XkbKeycodeToKeysym(X11Display_, static_cast<XIRawEvent*>(X11CurrentEventCookie->data)->detail, 0, 0)) << std::endl;
+            emit RawKeyPressedSignal(*static_cast<XIRawEvent*>(X11CurrentEventCookie->data));
+        }
+        if (X11CurrentEventCookie->evtype == XI_RawKeyRelease) {
+            std::cout << "RawKeyPressed, Symbol: " << XKeysymToString(XkbKeycodeToKeysym(X11Display_, static_cast<XIRawEvent*>(X11CurrentEventCookie->data)->detail, 0, 0)) << std::endl;
+            emit RawKeyReleasedSignal(*static_cast<XIRawEvent*>(X11CurrentEventCookie->data));
+        }
+    }
+}

--- a/cx11keyloggerworker.h
+++ b/cx11keyloggerworker.h
@@ -1,0 +1,30 @@
+#ifndef CX11KEYLOGGERWORKER_H
+#define CX11KEYLOGGERWORKER_H
+
+#include <QObject>
+#include <QThread>
+
+// X11 is the worst thing ever made so this includes will break all following includes => It must be included LAST
+#include <X11/XKBlib.h>
+#include <X11/extensions/XInput2.h>
+
+class CX11KeyloggerWorker : public QObject
+{
+    Q_OBJECT
+public:
+    explicit CX11KeyloggerWorker(QThread* myThread, QObject *parent = nullptr);
+
+signals:
+    void RawKeyPressedSignal(XIRawEvent);
+    void RawKeyReleasedSignal(XIRawEvent);
+
+public slots:
+    void StartLogging();
+
+private:
+    QThread *myThread_;
+    Display *X11Display_;
+    int xi_opcode_;
+};
+
+#endif // CX11KEYLOGGERWORKER_H


### PR DESCRIPTION
Сделал перехват клавиатуры для графического движка X11
Плюсы:
- работают в том числе кастомные настройки (по типу caps lock на самом деле shift)
- Не хочет sudo
- Работает

Минусы:
- Выглядит как костыль, пахнет как костыль и на вкус как костыль (крутится бесконечный цикл в отдельном QThread)
- Для завершения не достаточно просто закрыть окно программы, необходимо нажать или отпустить любую клавишу (потому что `XNextEvent` не дает возможностния и поставить timeout без извращений, а без его использования придется лезть в совсем низкоуровневые дебри)
- Сейчас в сигнале посылается структура `XIRawEvent`. Она в себя включает многое (deviceId, timer, etc.), но совсем уж просто добыть из нее keycode вроде нельзя. [Лучшая документация про нее](https://docs.factorcode.org/content/word-XIRawEvent%2Cx11.xinput2.ffi.html)
- Так же (вспомнил уже после добавления) разроботчики X11 - максимально нехорошие люди. Выражается это в том, что после `#include <X11/что угодно>` нельзя делать больше никаких Qt-шных `include`-ов (В X11 выставляются макросы, а потом эти же имена используются в Qt. Поэтому подключение X11 должно идти последним. Но это сейчас так и есть по модулю того, что аргумент сигнала - структура из X11.